### PR TITLE
Restyled Mozilla logo on index page for responsive layout, fixes #9

### DIFF
--- a/_layouts/index.html
+++ b/_layouts/index.html
@@ -7,7 +7,7 @@ layout: base
 	<div class="container text-center">
 		{% if site.jumbotron_image %}
 			<img src="{{ site.baseurl }}/img/{{ site.jumbotron_image }}"
-			     alt="{{ site.title }} Icon" height="180px width="200px" />
+			     alt="{{ site.title }} Icon" />
 		{% endif %}
 		<header>
 			<h1>{{ site.data.course.description }}</h1>

--- a/css/site.css
+++ b/css/site.css
@@ -4,6 +4,10 @@
 .jumbotron{
      background-image: url('../img/mozorg-gradient.png');
 }
+.jumbotron .container img {
+  width: 400px;
+  height: auto;
+}
 .jumbotron header h1 {
     font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 3.0em;
@@ -230,4 +234,11 @@ ul.submodule {
    white-space:nowrap;
   background-color:red;
 
+}
+
+@media screen and (max-width: 640px) {
+  .jumbotron .container img {
+    width: 200px;
+    height: auto;
+  }
 }


### PR DESCRIPTION
Removes inline styling (was broken due to wrong `&quot;`ing).
Implements width the CSS way.
Handles smaller screens.
