### PR TITLE
Fixes the awkward see-thru background of the "Start Here" button

### DIFF
--- a/_sass/_landing.scss
+++ b/_sass/_landing.scss
@@ -22,7 +22,6 @@ section {
 	background: $jumbotron-color;
 	background-position: bottom center;
 	background-repeat: no-repeat;
-	background-image: url('../img/#{$jumbotron-image}');
 	background-size: auto;
 	color: $white;
 	position: relative;

--- a/css/site.css
+++ b/css/site.css
@@ -1,9 +1,6 @@
 .content img {
     max-width: 100%;
 }
-.jumbotron{
-     background-image: url('../img/mozorg-gradient.png');
-}
 .jumbotron header h1 {
     font-family: "Open Sans","Helvetica Neue",Helvetica,Arial,sans-serif;
     font-size: 3.0em;


### PR DESCRIPTION
![mozcommed](https://cloud.githubusercontent.com/assets/536060/6949030/8d3a5216-d8cf-11e4-92d0-0e3ef9422f56.png)

Gah... that was an awkward hack.
Let's kill it with fire before it lays eggs!
