### PR TITLE
fix too many clicks, home page submodules, caret for firefoxos

### DIFF
--- a/_includes/navigation.html
+++ b/_includes/navigation.html
@@ -26,43 +26,44 @@
                {% assign dropdown = 1 %}
              {% endif %}
            {% endfor %}
-				       
+
 					{% assign first_post = site.categories[module]|reverse|first %}
 
-					<li class="{% if dropdown == 1 %}dropdown {%endif%} {% if page.categories[1] contains module %}active{% endif %} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}">
-						<a href="{{ site.baseurl }}{{ first_post.url }}"
+					<li class="{% if dropdown == 1 %}dropdown {%endif%} {% if page.categories[1] contains module %}active open{% endif %} {% if forloop.first %}first{% endif %} {% if forloop.last %}last{% endif %}">
+						<a {% if dropdown ==1 %}href="#" data-toggle="dropdown"{% else %}href="{{ site.baseurl }}{{ first_post.url }}"{% endif %}
 						   class="dropdown-item">
-							{{ module | replace:'_',' ' }}  
+							{{ module | replace:'_',' ' }}
 					 		{% if dropdown == 1 %}<b class="caret"></b>{% endif %}</a>
 
-					 <ul class="{% if dropdown == 1 %}dropdown-menu no-collapse {%endif%}"> 
+					 <ul class="{% if dropdown == 1 %}dropdown-menu no-collapse {%endif%}list-inline">
+						  {% if dropdown ==1 %}<li class=""><a href="{{ site.baseurl }}{{ first_post.url }}">Introduction</a></li> {% endif %}
 		       <!-- /submodules -->
 					{% for submodule in site.data.course.submodules %}
-					 
+
 					  {% if submodule contains module %}
 
     					  {% assign submodule_name = module | append: '_' %}
   						  {% assign submodule_first_post = site.categories[submodule]|reverse|first %}
   						  {% assign submodule_display_name =  submodule | replace: submodule_name,'' %}
-								
-						    <li class="" ><a href="{{ site.baseurl }}{{submodule_first_post.url}}" title="{{ submodule_display_name | replace:'_',' ' }} ">{% if page.categories[1] contains submodule%}<i class="fa fa-chevron-right"></i>&nbsp;{%endif%}{{ submodule_display_name | replace:'_',' ' }}</a></li>
+
+						    <li class="" ><a href="{{ site.baseurl }}{{submodule_first_post.url}}" title="{{ submodule_display_name | replace:'_',' ' }} ">{% comment %}{% if page.categories[1] contains submodule%}<i class="fa fa-chevron-right"></i>&nbsp;{%endif%}{% endcomment %}{{ submodule_display_name | replace:'_',' ' }}</a></li>
 
 
             {% endif %}
-           
+
 		      {% endfor %}
            </ul>
 
 					</li>
-					
+
 				{% endfor %}
 				<li>
 					<a href="https://discourse.mozilla-community.org/c/community-education" target="_blank">Discussion</a>
 				</li>
 			</ul>
-			
+
 		</div>
-		
+
 		<!-- /.navbar-collapse -->
 	</div>
 	<!-- /.container-fluid -->

--- a/_layouts/base.html
+++ b/_layouts/base.html
@@ -25,7 +25,7 @@
 	<link rel="apple-touch-icon" href="https://p2pu.org/static/images/apple-touch-icon.png">
 
 	<link rel="stylesheet" href="{{ site.baseurl }}/css/p2pustrap-custom.css" />
-	
+
 	<link rel="shortcut icon" href="{{ site.baseurl }}/img/favicon.ico">
 	<script type="text/javascript" src="{{ site.baseurl }}/js/modernizr-2.6.2.min.js"></script>
 
@@ -67,8 +67,8 @@
   }
 </script>
 <script src="https://apis.google.com/js/client.js?onload=get_calendar"></script>
-
-<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script>
+<!--
+<script src="//netdna.bootstrapcdn.com/bootstrap/3.1.1/js/bootstrap.min.js"></script> -->
 {% endif %}
 
 <!-- Google Analytics -->

--- a/css/site.css
+++ b/css/site.css
@@ -82,15 +82,17 @@ li.dropdown > ul:nth-child(n){
 
 li.dropdown:nth-child(n) > ul:nth-child(n) > li:nth-child(n) > a:nth-child(n){
    background-color:#515665;
-
+   color: #ccc;
 }
+/*
 li.dropdown:nth-child(n) > ul:nth-child(n) > li:nth-child(n){
      width:100%;
 }
-
+*/
 li.dropdown:nth-child(n) > ul:nth-child(n) > li:nth-child(n) > a:nth-child(n):hover{
    background-color:#707782;
   }
+
 .navbar-nav > li > a {
     line-height: 2;
 }
@@ -101,4 +103,9 @@ li.dropdown:nth-child(n) > ul:nth-child(n) > li:nth-child(n) > a:nth-child(n):ho
       opacity: 1;
       display: block;
   }
+}
+
+
+.navbar-default .navbar-nav .dropdown-menu {
+    background-color: #515665;
 }


### PR DESCRIPTION
Fixes #26 mainly. Keeps the active menu open, but also allows clicking other menus to open them. To go to the introduction page, an "introduction" item is added to the menu.
#8 will not apply to this fix because we aren't using hover. Everything is on clicks. And that also means this works on Android like you asked in #26
#19 can be closed :smile:

Also fixed the inappropriate caret mentioned in #24 .

Screenshots! Screenshots!

![screenshot from 2015-04-12 11 31 13](https://cloud.githubusercontent.com/assets/945777/7104558/4b360982-e108-11e4-9316-330655f160a7.png)
![screenshot from 2015-04-12 11 30 47](https://cloud.githubusercontent.com/assets/945777/7104559/4b3e80c6-e108-11e4-9919-67c44c85e91b.png)
![screenshot from 2015-04-12 11 30 37](https://cloud.githubusercontent.com/assets/945777/7104560/4b6340e6-e108-11e4-82a4-287e7a56ec65.png)
