### PR TITLE
Rename href of the link to platform repository

### DIFF
--- a/index.markdown
+++ b/index.markdown
@@ -28,5 +28,5 @@ Join our Community Education Call!  <a target="_blank" href=https://wiki.mozilla
 
 <hr>
 
-<i class="fa fa-github fa-2x" ></i> [This platform](https://github.com/emmairwin/reps-edu/) and [all curriculum](https://github.com/emmairwin/community_curriculum) can be found on Github, please help us improve and localize.
+<i class="fa fa-github fa-2x" ></i> [This platform](https://github.com/emmairwin/mozilla-community-edu/) and [all curriculum](https://github.com/emmairwin/community_curriculum) can be found on Github, please help us improve and localize.
 		


### PR DESCRIPTION
Although reps-edu automatically redirects to mozilla-community-edu, it shows up as reps-edu on hover and is confusing.
