### PR TITLE
Proof of concept in reps_mentor_training to directly edit on github

### DIFF
--- a/_layouts/course_page.html
+++ b/_layouts/course_page.html
@@ -9,6 +9,8 @@ layout: base
 		<div class="col-md-8 col-md-offset-1">
 			<div class="row">
 				<div class="content col-lg-12">
+					{% assign ccurl = page.url | split: "/" | last %}
+					<a href="https://github.com/emmairwin/community_curriculum/edit/master/reps/mentor_training/en/{{ccurl}}.md"><i class="fa fa-github"></i> Suggest Changes</a>
 					{{ content }}
 					{% include next_in_module.html %}
 					{% if prev or next %}


### PR DESCRIPTION
This is just a proof of concept for mozilla/participation-org#230 .
Check out pages inside reps_mentor_training module to see it in action. Other pages will show the suggest changes button with wrong/no functionality.

More comments on the upstream issue.
